### PR TITLE
Fix empresa registration RLS owner id and expose toast notifications

### DIFF
--- a/app/api/empresa/route.ts
+++ b/app/api/empresa/route.ts
@@ -70,7 +70,7 @@ export async function POST(
       .eq("auth_user_id", user.id)
       .maybeSingle();
 
-    let ownerRnc = usuario?.rnc_cedula;
+    let ownerRnc = usuario?.rnc_cedula?.trim();
     let usuarioId = usuario?.id;
 
     if (!usuario) {
@@ -84,7 +84,7 @@ export async function POST(
             nombre: user.user_metadata?.nombre || "",
             email: user.email,
             password_hash: "supabase_auth",
-            rnc_cedula: body.rnc,
+            rnc_cedula: empresaInput.rnc,
             rol: "administrador",
             activo: true,
             created_at: new Date().toISOString(),
@@ -105,11 +105,13 @@ export async function POST(
         );
       }
 
-      ownerRnc = newUser.rnc_cedula;
+      ownerRnc = newUser.rnc_cedula?.trim();
       usuarioId = newUser.id;
     }
 
-    if (!ownerRnc) {
+    const normalizedOwnerId = ownerRnc || empresaInput.rnc;
+
+    if (!normalizedOwnerId) {
       return NextResponse.json(
         { success: false, error: "RNC no encontrado para el usuario" },
         { status: 400 },
@@ -123,7 +125,7 @@ export async function POST(
       .upsert(
         {
           ...empresaInput,
-          owner_id: user.id,
+          owner_id: normalizedOwnerId,
           updated_at: new Date().toISOString(),
         },
         { onConflict: ["owner_id"] },

--- a/app/clientLayout.tsx
+++ b/app/clientLayout.tsx
@@ -8,6 +8,7 @@ import Header from "@/components/layout/header"
 import MobileNavigation from "@/components/layout/mobile-navigation"
 import { createClient } from "@/utils/supabase/client"
 import { fetchEmpresaConfig } from "@/lib/helpers/empresa-config"
+import { Toaster } from "@/components/ui/toaster"
 
 interface UserData {
   id: string
@@ -109,7 +110,12 @@ export default function ClientLayout({
 
   // Si es página de auth, mostrar sin layout
   if (isAuthPage) {
-    return <>{children}</>
+    return (
+      <>
+        {children}
+        <Toaster />
+      </>
+    )
   }
 
   // Si no está autenticado, no mostrar nada (ya se redirigió)
@@ -137,6 +143,7 @@ export default function ClientLayout({
 
       {/* Mobile Navigation */}
       <MobileNavigation />
+      <Toaster />
     </div>
   )
 }

--- a/components/empresa-context.tsx
+++ b/components/empresa-context.tsx
@@ -7,6 +7,7 @@ export interface EmpresaProfile {
   razon_social: string
   nombre_comercial?: string
   rnc: string
+  owner_id?: string | null
   direccion?: string
   telefono?: string
   email?: string

--- a/lib/auth-service.ts
+++ b/lib/auth-service.ts
@@ -148,11 +148,13 @@ export async function registrarEmpresa(data: RegistroEmpresaData): Promise<Regis
 
     authLogger.info(`Usuario creado en Auth: ${authData.user.id}`)
 
-    // 3. Crear empresa con owner_id (CLAVE: esto resuelve el problema RLS)
-    authLogger.info(`Creando empresa con owner_id: ${authData.user.id}`)
+    const empresaRnc = data.empresa_rnc.trim()
+
+    // 3. Crear empresa con owner_id usando el RNC del propietario
+    authLogger.info(`Creando empresa con owner_id (RNC): ${empresaRnc}`)
 
     const empresaData = {
-      rnc: data.empresa_rnc,
+      rnc: empresaRnc,
       razon_social: data.empresa_razon_social,
       nombre_comercial: data.empresa_nombre_comercial || null,
       email: data.empresa_email,
@@ -160,7 +162,7 @@ export async function registrarEmpresa(data: RegistroEmpresaData): Promise<Regis
       direccion: data.empresa_direccion || null,
       provincia: data.empresa_provincia || null,
       municipio: data.empresa_municipio || null,
-      owner_id: authData.user.id,
+      owner_id: empresaRnc,
       activa: true,
       fecha_registro: new Date().toISOString(),
       fecha_actualizacion: new Date().toISOString(),

--- a/lib/supabase-server-utils.ts
+++ b/lib/supabase-server-utils.ts
@@ -42,11 +42,13 @@ export class SupabaseServerUtils {
       return usuario.empresas
     }
 
+    const ownerRnc = usuario?.rnc_cedula?.trim() || ""
+
     // Buscar empresa por owner_id usando el RNC del usuario
     const { data: empresa, error: empresaError } = await supabase
       .from("empresas")
       .select("*")
-      .eq("owner_id", usuario?.rnc_cedula || "")
+      .eq("owner_id", ownerRnc)
       .maybeSingle()
 
     if (empresaError || !empresa) {
@@ -83,11 +85,13 @@ export class SupabaseServerUtils {
       }
     }
 
+    const ownerRnc = usuario?.rnc_cedula?.trim() || ""
+
     // Fallback: buscar empresa por owner_id usando el RNC del usuario
     const { data: empresa, error: empresaError } = await supabase
       .from("empresas")
       .select("*")
-      .eq("owner_id", usuario?.rnc_cedula || "")
+      .eq("owner_id", ownerRnc)
       .maybeSingle()
 
     if (empresaError || !empresa) {

--- a/types/database.ts
+++ b/types/database.ts
@@ -498,6 +498,7 @@ export interface Database {
           direccion: string | null
           provincia: string | null
           municipio: string | null
+          owner_id: string | null
           activa: boolean
           created_at: string
           updated_at: string
@@ -512,6 +513,7 @@ export interface Database {
           direccion?: string | null
           provincia?: string | null
           municipio?: string | null
+          owner_id?: string | null
           activa?: boolean
           created_at?: string
           updated_at?: string
@@ -526,6 +528,7 @@ export interface Database {
           direccion?: string | null
           provincia?: string | null
           municipio?: string | null
+          owner_id?: string | null
           activa?: boolean
           created_at?: string
           updated_at?: string


### PR DESCRIPTION
## Summary
- normalize empresa registration to use the RNC as owner_id when creating or updating company data so row-level security policies permit the insert
- refresh helpers, shared utilities, and generated types to read/write companies via the owner RNC and trim stored values
- add the global toast provider to the client layout so authentication flows show feedback to the user

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68c850d8c0608323b2ef8cc4551bd800